### PR TITLE
Logging w/ namespaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,27 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": []
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Mocha (Test single file)",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "${workspaceRoot}/node_modules/.bin/mocha",
+        "-r",
+        "ts-node/register/transpile-only",
+        "--exit",
+        "--inspect-brk",
+        "${relativeFile}"
+      ],
+      "runtimeExecutable": "${env:NVM_BIN}/node",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229,
+      "cwd": "${workspaceRoot}",
+      "env": {}
+    }
+  ]
 }

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -29,7 +29,22 @@ interface ILogOptions {
 	customAdapter?: LogAdapter
 	/** Whether to show file path / line numbers for all logs instead of just debug and trace. Enabling this will incur a slight performance penalty.*/
 	showLineNumbersForAll?: boolean
-	/** If this is a module, set the namespace so logs can be selectively turned on. For example @sprucelabs/skill-booking. The default namespace is read from the CWD package.json */
+	/**
+	 * If this is a module, set the namespace so logs can be selectively turned on.
+	 *
+	 * For example, if the module is named @sprucelabs/foo
+	 *
+	 * You can turn on debugging by setting the environment variable:
+	 * DEBUG=@sprucelabs/foo
+	 * or with a wildcard
+	 * DEBUG=@sprucelabs/*
+	 *
+	 * You can also specify the level:
+	 * DEBUG=@sprucelabs/foo~trace,@sprucelabs/bar~crit
+	 *
+	 * By default, when a namespace is set, the level is set to "warn"
+	 *
+	 * */
 	namespace?: string
 }
 

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -503,6 +503,9 @@ export class Log {
 			const level = this.getDefaultLevelForNamespace(this.namespace, debugStr)
 			if (level) {
 				this.setLevel(level)
+			} else {
+				// Default log level when namespace is set
+				this.setLevel(LogLevel.Warn)
 			}
 		}
 	}

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -29,6 +29,8 @@ interface ILogOptions {
 	customAdapter?: LogAdapter
 	/** Whether to show file path / line numbers for all logs instead of just debug and trace. Enabling this will incur a slight performance penalty.*/
 	showLineNumbersForAll?: boolean
+	/** If this is a module, set the namespace so logs can be selectively turned on. For example @sprucelabs/skill-booking. The default namespace is read from the CWD package.json */
+	namespace?: string
 }
 
 interface ICaller {
@@ -49,6 +51,7 @@ export class Log {
 	private level: LogLevel = LogLevel.Info
 	private customAdapter?: LogAdapter
 	private consoleAdapter!: LogAdapter
+	private namespace?: string
 
 	private levels = {
 		[LogLevel.Trace]: {
@@ -102,8 +105,9 @@ export class Log {
 	}
 
 	public constructor(options?: ILogOptions) {
-		this.setOptions(options)
 		this.setConsoleAdapter()
+		this.setDefaultOptions()
+		this.setOptions(options)
 	}
 
 	/** Trace level logs the go beyond just normal debug messages. A silly log level. */
@@ -179,8 +183,10 @@ export class Log {
 	public setOptions(options?: ILogOptions) {
 		if (!options) {
 			// Nothing to set
+			this.debugLog('setOptions() called without any options')
 			return
 		}
+		this.debugLog('Setting options', { options })
 
 		if (typeof options.asJSON === 'boolean') {
 			this.asJSON = options.asJSON
@@ -200,6 +206,10 @@ export class Log {
 
 		if (typeof options.showLineNumbersForAll === 'boolean') {
 			this.showLineNumbersForAll = options.showLineNumbersForAll
+		}
+
+		if (typeof options.namespace === 'string' && options.namespace.length > 0) {
+			this.namespace = options.namespace
 		}
 	}
 
@@ -245,11 +255,38 @@ export class Log {
 		}
 	}
 
-	private handleLog(options: { level: LogLevel; args: any[] }) {
-		const { level, args } = options
+	private getLevelFromString(level: string): LogLevel {
+		switch (level) {
+			case LogLevel.Trace:
+			case LogLevel.Debug:
+			case LogLevel.Info:
+			case LogLevel.Warn:
+			case LogLevel.Error:
+			case LogLevel.Crit:
+			case LogLevel.Fatal:
+			case LogLevel.SuperInfo:
+				return level
+			default:
+				return LogLevel.Debug
+		}
+	}
+
+	private handleLog(options: {
+		/** The log level to log at */
+		level: LogLevel
+		/** Anything you want to log */
+		args: any[]
+		/** Force log ignoring this.level  */
+		force?: boolean
+		/** Override the current namespace. Setting this will take precedent over this.namespace */
+		namespace?: string
+	}) {
+		const { level, args, force } = options
+		const namespace = options.namespace ?? this.namespace
+
 		if (
-			this.levels[level] &&
-			this.levels[level].i >= this.levels[this.level].i
+			force ||
+			(this.levels[level] && this.levels[level].i >= this.levels[this.level].i)
 		) {
 			const now = this.getDatetimeString()
 			let caller: ICaller | undefined
@@ -264,6 +301,7 @@ export class Log {
 			if (this.asJSON) {
 				const jsonThing = `${JSON.stringify(
 					{
+						namespace,
 						timestamp: now,
 						level,
 						message: args,
@@ -277,7 +315,9 @@ export class Log {
 				const callerStr = caller?.relativeFilePath
 					? ` | ${caller.relativeFilePath}`
 					: ''
-				const rawAboutStr = `(${level.toUpperCase()} | ${now}${callerStr}): `
+
+				const namespaceStr = namespace ? `  [${namespace}] ` : ''
+				const rawAboutStr = `${namespaceStr}(${level.toUpperCase()} | ${now}${callerStr}): `
 
 				if (args.length === 1 && typeof args[0] === 'string') {
 					const str = CLIENT
@@ -290,7 +330,8 @@ export class Log {
 				} else if (Array.isArray(args)) {
 					this.writeLog(rawAboutStr)
 					args.forEach((arg: any) => {
-						const str = this.anyToString(arg)
+						const addIndentation = typeof namespace !== 'undefined'
+						const str = this.anyToString(arg, addIndentation)
 						this.writeLog(this.colorize({ str, level }))
 					})
 				}
@@ -298,14 +339,19 @@ export class Log {
 		}
 	}
 
-	private anyToString(thing: any): string {
+	private anyToString(thing: any, addIndentation?: boolean): string {
 		const thingType = typeof thing
 
 		switch (thingType) {
 			case 'undefined':
 				return 'undefined'
-			case 'string':
-				return thing
+			case 'string': {
+				let thingStr = thing
+				if (addIndentation) {
+					thingStr = `  ${thingStr}`
+				}
+				return thingStr
+			}
 			case 'number':
 			case 'bigint':
 			case 'boolean':
@@ -313,8 +359,18 @@ export class Log {
 			case 'symbol':
 			case 'object':
 			case 'function':
-			default:
-				return JSON.stringify(thing, this.replaceErrors, this.objectSpaceWidth)
+			default: {
+				let thingStr = JSON.stringify(
+					thing,
+					this.replaceErrors,
+					this.objectSpaceWidth
+				)
+				if (addIndentation) {
+					thingStr = thingStr.replace(/\n/g, '\n  ')
+					thingStr = `  ${thingStr}`
+				}
+				return thingStr
+			}
 		}
 	}
 
@@ -424,23 +480,76 @@ export class Log {
 		return value
 	}
 
-	private debugLog(msg: string) {
+	/** Logs a debug message about @sprucelabs/log itself */
+	private debugLog(...args: any) {
 		const namespace = '@sprucelabs/log'
-		const adapter = this.getAdapter()
-		const fullMsg = `${namespace} | ${msg}`
+		const debugStr = this.getDebugString()
+		const level = this.getDefaultLevelForNamespace(namespace, debugStr)
 
+		if (level && this.levels[level].i <= this.levels[LogLevel.Debug].i) {
+			this.handleLog({
+				level: LogLevel.Debug,
+				force: true,
+				namespace,
+				args
+			})
+		}
+	}
+
+	private setDefaultOptions() {
+		const debugStr = this.getDebugString()
+
+		// Check if our current namespace
+		if (this.namespace) {
+			const level = this.getDefaultLevelForNamespace(this.namespace, debugStr)
+			if (level) {
+				this.setLevel(level)
+			}
+		}
+	}
+
+	private getDebugString() {
+		let debugStr = ''
 		if (CLIENT && typeof localStorage !== 'undefined') {
 			// eslint-disable-next-line no-undef
 			const lsDebug = localStorage.getItem('debug')
-			if (lsDebug && lsDebug.indexOf(namespace)) {
-				adapter(fullMsg)
+			if (lsDebug) {
+				debugStr = lsDebug
 			}
-		} else if (
-			typeof process !== 'undefined' &&
-			process.env.DEBUG &&
-			process.env.DEBUG.indexOf(namespace) > -1
-		) {
-			adapter(fullMsg)
+		} else if (typeof process !== 'undefined' && process.env.DEBUG) {
+			debugStr = process.env.DEBUG
+		}
+
+		return debugStr
+	}
+
+	private getDefaultLevelForNamespace(namespace: string, debugStr: string) {
+		if (namespace) {
+			// Set the namespace based on the package.json
+			const debugNamespaces = debugStr.split(',')
+			for (let i = 0; i < debugNamespaces.length; i += 1) {
+				const ns = debugNamespaces[i]
+				const { namespace: parsedNamespace, level } = this.parseNamespace(ns)
+				const namespaceToCheck = parsedNamespace.replace(/\*/g, '')
+
+				if (
+					parsedNamespace.length > 0 &&
+					(parsedNamespace === '*' || namespaceToCheck.indexOf(namespace) > -1)
+				) {
+					return level
+				}
+			}
+		}
+
+		return
+	}
+
+	private parseNamespace(ns: string) {
+		const [namespace, level] = ns.split('~')
+
+		return {
+			namespace,
+			level: this.getLevelFromString(level)
 		}
 	}
 

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -210,6 +210,7 @@ export class Log {
 
 		if (typeof options.namespace === 'string' && options.namespace.length > 0) {
 			this.namespace = options.namespace
+			this.setDefaultOptions()
 		}
 	}
 
@@ -498,8 +499,6 @@ export class Log {
 
 	private setDefaultOptions() {
 		const debugStr = this.getDebugString()
-
-		// Check if our current namespace
 		if (this.namespace) {
 			const level = this.getDefaultLevelForNamespace(this.namespace, debugStr)
 			if (level) {
@@ -534,7 +533,7 @@ export class Log {
 
 				if (
 					parsedNamespace.length > 0 &&
-					(parsedNamespace === '*' || namespaceToCheck.indexOf(namespace) > -1)
+					(parsedNamespace === '*' || namespace.indexOf(namespaceToCheck) > -1)
 				) {
 					return level
 				}

--- a/tests/LogNamespaceTests.ts
+++ b/tests/LogNamespaceTests.ts
@@ -1,0 +1,108 @@
+import { assert } from 'chai'
+import Base from './Base'
+import faker from 'faker'
+import log from '../index'
+import { LogLevel } from '../src/logLevel'
+
+class LogLevelTests extends Base {
+	private namespace!: string
+
+	private customLevels = {
+		levels: {
+			trace: 7,
+			debug: 6,
+			info: 5,
+			warn: 4,
+			error: 3,
+			crit: 2,
+			fatal: 1,
+			superInfo: 0
+		},
+		colors: {
+			trace: 'gray',
+			debug: 'green',
+			info: 'cyan',
+			warn: 'yellow',
+			error: 'red',
+			crit: 'red',
+			fatal: 'red',
+			superInfo: 'cyan'
+		}
+	}
+
+	public setup() {
+		it('Can set a namespace and log debug logs by default', () =>
+			this.setNamespace(LogLevel.Debug))
+		it('Can set a namespace and log debug', () =>
+			this.setNamespace(LogLevel.Debug, LogLevel.Debug))
+		it('Can set a namespace and log debug', () =>
+			this.setNamespace(LogLevel.Trace))
+		it('Logs namespaces properly', () => this.logNamespaces())
+	}
+
+	public async before() {
+		await super.before()
+		this.namespace = faker.name.firstName()
+		log.setOptions({
+			namespace: this.namespace
+		})
+	}
+
+	public async setNamespace(level: LogLevel, logLevel?: LogLevel) {
+		const message = faker.lorem.words()
+
+		const currentLogLevel = logLevel ? logLevel : LogLevel.Debug
+		log.setOptions({
+			level: currentLogLevel
+		})
+
+		const shouldLog =
+			this.customLevels.levels[currentLogLevel] >=
+			this.customLevels.levels[level]
+
+		let wasLogged = false
+
+		log.setOptions({
+			customAdapter: logMessage => {
+				wasLogged = true
+				if (!shouldLog) {
+					throw new Error(
+						`Level ${level} should not log for log level ${logLevel}`
+					)
+				}
+				const levelRegexp = new RegExp(level, 'i')
+				assert.isTrue(levelRegexp.test(logMessage))
+				const messageRegexp = new RegExp(message, 'i')
+				assert.isTrue(messageRegexp.test(message))
+			}
+		})
+		console.log({
+			level,
+			logLevel,
+			shouldLog
+		})
+		log[level](message)
+		assert.equal(wasLogged, shouldLog)
+	}
+
+	public async logNamespaces() {
+		const message = faker.lorem.words()
+
+		let hasNamespacePrefix = false
+
+		log.setOptions({
+			customAdapter: logMessage => {
+				if (logMessage.indexOf(`[${this.namespace}]`) > -1) {
+					hasNamespacePrefix = true
+				}
+			}
+		})
+
+		log.fatal(message)
+		assert.isTrue(hasNamespacePrefix)
+	}
+}
+
+describe('LogLevelTests', function Tests() {
+	new LogLevelTests()
+})


### PR DESCRIPTION
Enables optionally setting a `namespace` which then allows us to selectively turn on logs and set levels for libraries using the `DEBUG` environment variable server side or `debug` localStorage item client side. This follow the conventions of the debug library we've used previously.

Example:
`DEBUG=@sprucelabs/log,@sprucelabs/autoloader~trace`

This would set the log level to debug for the log library and to trace for the autoloader

By default, log instances with namespaces will log `warn` level logs