### PR TITLE
Properly handle circular references

### DIFF
--- a/src/Log.ts
+++ b/src/Log.ts
@@ -4,6 +4,7 @@
 import { TerminalColors } from './lib/terminal'
 import { LogLevel } from './logLevel'
 import StackUtils from './lib/StackUtils'
+import jsonStringify from './lib/jsonStringify'
 
 declare global {
 	const __webpack_require__: any | undefined
@@ -320,7 +321,7 @@ export class Log {
 			}
 
 			if (this.asJSON) {
-				const jsonThing = `${JSON.stringify(
+				const jsonThing = `${jsonStringify(
 					{
 						namespace,
 						timestamp: now,
@@ -387,7 +388,7 @@ export class Log {
 			case 'object':
 			case 'function':
 			default: {
-				let thingStr = JSON.stringify(
+				let thingStr = jsonStringify(
 					thing,
 					this.replaceErrors,
 					this.objectSpaceWidth

--- a/src/lib/jsonStringify.ts
+++ b/src/lib/jsonStringify.ts
@@ -1,0 +1,68 @@
+// Adapted from https://github.com/debitoor/safe-json-stringify
+
+const hasProp = Object.prototype.hasOwnProperty
+
+function throwsMessage(err?: Error) {
+	return '[Throws: ' + (err ? err.message : '?') + ']'
+}
+
+function safeGetValueFromPropertyOnObject(obj: any, property: any) {
+	if (hasProp.call(obj, property)) {
+		try {
+			return obj[property]
+		} catch (err) {
+			return throwsMessage(err)
+		}
+	}
+
+	return obj[property]
+}
+
+function ensureProperties(obj: any) {
+	const seen: any[] = [] // store references to objects we have seen before
+
+	function visit(obj: any): any {
+		if (obj === null || typeof obj !== 'object') {
+			return obj
+		}
+
+		if (seen.indexOf(obj) !== -1) {
+			return '[Circular]'
+		}
+		seen.push(obj)
+
+		if (typeof obj.toJSON === 'function') {
+			try {
+				const fResult = visit(obj.toJSON())
+				seen.pop()
+				return fResult
+			} catch (err) {
+				return throwsMessage(err)
+			}
+		}
+
+		if (Array.isArray(obj)) {
+			const aResult = obj.map(visit)
+			seen.pop()
+			return aResult
+		}
+
+		const result: any = Object.keys(obj).reduce(function(result: any, prop) {
+			// prevent faulty defined getter properties
+			result[prop] = visit(safeGetValueFromPropertyOnObject(obj, prop))
+			return result
+		}, {})
+		seen.pop()
+		return result
+	}
+
+	return visit(obj)
+}
+
+export default function(
+	value: any,
+	replacer?: (this: any, key: string, value: any) => any,
+	space?: string | number
+): string {
+	return JSON.stringify(ensureProperties(value), replacer, space)
+}

--- a/tests/LogTests.ts
+++ b/tests/LogTests.ts
@@ -3,11 +3,13 @@ import Base from './Base'
 import faker from 'faker'
 import log from '../index'
 import { LogLevel } from '../src/logLevel'
+import jsonStringify from '../src/lib/jsonStringify'
 
 class LoggingTests extends Base {
 	public setup() {
 		it('Uses colors', () => this.useColors())
 		it('Can have colors turned off', () => this.noColors())
+		it('Can stringify circular references', () => this.stringifyCircular())
 	}
 
 	public async before() {
@@ -50,6 +52,26 @@ class LoggingTests extends Base {
 
 		log.debug(message)
 		assert.isTrue(wasLogged)
+	}
+
+	public async stringifyCircular() {
+		const a: Record<string, any> = {
+			b: null
+		}
+		const b = { a }
+		a.b = b
+
+		let didThrow = false
+		try {
+			JSON.stringify(a)
+		} catch (e) {
+			didThrow = true
+		}
+
+		assert.isTrue(didThrow)
+
+		jsonStringify(a)
+		assert.isTrue(true)
 	}
 }
 


### PR DESCRIPTION
Previously, objects sent to the logger w/ circular references would throw an error